### PR TITLE
Update demo compare command invocation

### DIFF
--- a/install/demo.rst
+++ b/install/demo.rst
@@ -63,19 +63,19 @@ The demo will take a minute or two to execute (depending upon your machine), and
 Upon successful completion, the top-level directory will contain an output ASCII table that can be compared to the expected results from a reference run.
 This table is for convenience only, and would not ordinarily be produced by the production LSST pipelines.  
 
-=============== ========================== ===================================
-Demo Invocation Demo Output                Reference output
-=============== ========================== ===================================
-demo.sh         detected-sources.txt       detected-sources.txt.expected
-demo.sh --small detected-sources_small.txt detected-sources_small.txt.expected
-=============== ========================== ===================================
+=============== ==========================
+Demo Invocation Demo Output               
+=============== ==========================
+demo.sh         detected-sources.txt      
+demo.sh --small detected-sources_small.txt
+=============== ==========================
 
 The demo output may not be identical to the reference output due to minor variation in numerical routines between operating systems (see :jira:`DM-1086` for details).
 The :command:`bin/compare` script will check whether the output matches the reference to within expected tolerances:
 
 .. code-block:: bash
 
-   bin/compare detected-sources.txt.expected detected-sources.txt
+   ./bin/compare detected-sources.txt
 
 The script will print "``Ok``" if the demo ran correctly.
 


### PR DESCRIPTION
The demo bin/compare command no longer takes the expected output file as an argument.